### PR TITLE
Replace PADDLE_CROSS_ENTROPY_WARP_SIZE with general PADDLE_WARP_SIZE macro

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -356,11 +356,6 @@ if(WITH_CUTLASS)
   add_definitions("-DPADDLE_WITH_MEMORY_EFFICIENT_ATTENTION"
   )# for memory_efficient_attention.h
 endif()
-if(WITH_GPU)
-  add_definitions(-DPADDLE_CROSS_ENTROPY_WARP_SIZE=32)
-else()
-  add_definitions(-DPADDLE_CROSS_ENTROPY_WARP_SIZE=64)
-endif()
 if(WITH_FLASHATTN)
   add_dependencies(phi flashattn)
 endif()

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -356,6 +356,20 @@ if(WITH_CUTLASS)
   add_definitions("-DPADDLE_WITH_MEMORY_EFFICIENT_ATTENTION"
   )# for memory_efficient_attention.h
 endif()
+# PADDLE_WARP_SIZE: warp size for the target GPU platform.
+# Default 32 (NVIDIA). Override via -DPADDLE_WARP_SIZE=64 for iluvatar (COREX).
+if(NOT DEFINED PADDLE_WARP_SIZE)
+  set(PADDLE_WARP_SIZE 32)
+endif()
+math(EXPR PADDLE_WARP_MASK "${PADDLE_WARP_SIZE} - 1")
+if(PADDLE_WARP_SIZE EQUAL 64)
+  set(PADDLE_WARP_SHIFT 6)
+else()
+  set(PADDLE_WARP_SHIFT 5)
+endif()
+add_definitions(-DPADDLE_WARP_SIZE=${PADDLE_WARP_SIZE})
+add_definitions(-DPADDLE_WARP_MASK=${PADDLE_WARP_MASK})
+add_definitions(-DPADDLE_WARP_SHIFT=${PADDLE_WARP_SHIFT})
 if(WITH_FLASHATTN)
   add_dependencies(phi flashattn)
 endif()

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -35,11 +35,11 @@ namespace phi {
 
 #define ALIGN_BYTES 16
 
-#ifndef PADDLE_CROSS_ENTROPY_WARP_SIZE
-#define PADDLE_CROSS_ENTROPY_WARP_SIZE 32
+#ifndef PADDLE_WARP_SIZE
+#define PADDLE_WARP_SIZE 32
 #endif
-#define PADDLE_CE_WARP_MASK (PADDLE_CROSS_ENTROPY_WARP_SIZE - 1)
-#define PADDLE_CE_WARP_SHIFT (PADDLE_CROSS_ENTROPY_WARP_SIZE == 64 ? 6 : 5)
+#define PADDLE_WARP_MASK (PADDLE_WARP_SIZE - 1)
+#define PADDLE_WARP_SHIFT (PADDLE_WARP_SIZE == 64 ? 6 : 5)
 
 enum class SoftmaxMode { kSoftmax, kLogSoftmax, kCrossEntropy };
 
@@ -119,7 +119,7 @@ __global__ void CrossEntropySoftLabel(T* loss,
 
   const int kThreadPerBlock = 512;
   const int kBatchPerBlock = 1;
-  const int kWarpSize = PADDLE_CROSS_ENTROPY_WARP_SIZE;
+  const int kWarpSize = PADDLE_WARP_SIZE;
   const int kBatchSize = 1;
   const int kThreadPerBatch = kThreadPerBlock / kBatchPerBlock;
   const int kWarpPerBatch = kThreadPerBatch / kWarpSize;
@@ -336,17 +336,17 @@ __device__ __forceinline__ T WarpReduceMaxDown(T val) {
 
 template <typename T>
 __device__ __forceinline__ T BlockReduceSumDown(T val) {
-  __shared__ T shared[PADDLE_CROSS_ENTROPY_WARP_SIZE];
+  __shared__ T shared[PADDLE_WARP_SIZE];
   int tid = threadIdx.x;
-  int lane = tid & PADDLE_CE_WARP_MASK;
-  int wid = tid >> PADDLE_CE_WARP_SHIFT;
+  int lane = tid & PADDLE_WARP_MASK;
+  int wid = tid >> PADDLE_WARP_SHIFT;
   val = WarpReduceSumDown(val);
   __syncthreads();
   if (lane == 0) {
     shared[wid] = val;
   }
   __syncthreads();
-  int warps = (blockDim.x + warpSize - 1) >> PADDLE_CE_WARP_SHIFT;
+  int warps = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   val = (tid < warps) ? shared[lane] : static_cast<T>(0.0f);
   if (wid == 0) {
     val = WarpReduceSumDown(val);
@@ -360,17 +360,17 @@ __device__ __forceinline__ T BlockReduceSumDown(T val) {
 
 template <typename T>
 __device__ __forceinline__ T BlockReduceMaxDown(T val) {
-  __shared__ T shared[PADDLE_CROSS_ENTROPY_WARP_SIZE];
+  __shared__ T shared[PADDLE_WARP_SIZE];
   int tid = threadIdx.x;
-  int lane = tid & PADDLE_CE_WARP_MASK;
-  int wid = tid >> PADDLE_CE_WARP_SHIFT;
+  int lane = tid & PADDLE_WARP_MASK;
+  int wid = tid >> PADDLE_WARP_SHIFT;
   val = WarpReduceMaxDown(val);
   __syncthreads();
   if (lane == 0) {
     shared[wid] = val;
   }
   __syncthreads();
-  int warps = (blockDim.x + warpSize - 1) >> PADDLE_CE_WARP_SHIFT;
+  int warps = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   val = (tid < warps) ? shared[lane] : -std::numeric_limits<T>::infinity();
   if (wid == 0) {
     val = WarpReduceMaxDown(val);
@@ -787,9 +787,9 @@ __global__ void WarpSoftmaxForwardSoftLabel(T* loss,
   const bool LogMode = true;
 
   constexpr int kDimCeil = 1 << Log2Elements;
-  constexpr int kWarpSize = (kDimCeil < PADDLE_CROSS_ENTROPY_WARP_SIZE)
+  constexpr int kWarpSize = (kDimCeil < PADDLE_WARP_SIZE)
                                 ? kDimCeil
-                                : PADDLE_CROSS_ENTROPY_WARP_SIZE;
+                                : PADDLE_WARP_SIZE;
   constexpr int kVSize = sizeof(VecT) / sizeof(T);
   constexpr int kIterations = kDimCeil / kWarpSize;
   constexpr int kIterationsV =
@@ -1007,9 +1007,9 @@ static void SoftmaxWithCrossEntropySoftLabel(const GPUContext& dev_ctx,
   }
 
   if (D == 1 && dim <= max_dim) {
-    int kWarpSize = (kDimCeil < PADDLE_CROSS_ENTROPY_WARP_SIZE)
+    int kWarpSize = (kDimCeil < PADDLE_WARP_SIZE)
                         ? kDimCeil
-                        : PADDLE_CROSS_ENTROPY_WARP_SIZE;
+                        : PADDLE_WARP_SIZE;
     int batches_per_warp = (kDimCeil <= 128) ? 2 : 1;
 
     // use 128 threads per block to maximize gpu utilization
@@ -1112,9 +1112,9 @@ __global__ void WarpSoftmaxForward(T* loss,
                                    const int element_count,
                                    const int ignore_index) {
   constexpr int kDimCeil = 1 << Log2Elements;
-  constexpr int kWarpSize = (kDimCeil < PADDLE_CROSS_ENTROPY_WARP_SIZE)
+  constexpr int kWarpSize = (kDimCeil < PADDLE_WARP_SIZE)
                                 ? kDimCeil
-                                : PADDLE_CROSS_ENTROPY_WARP_SIZE;
+                                : PADDLE_WARP_SIZE;
   constexpr int kVSize = sizeof(VecT) / sizeof(T);
   constexpr int kIterations = kDimCeil / kWarpSize;
   constexpr int kIterationsV =
@@ -1354,9 +1354,9 @@ __global__ void WarpSoftmaxForwardCompatible(T* loss,
                                              const int element_count,
                                              const int ignore_index) {
   constexpr int kDimCeil = 1 << Log2Elements;
-  constexpr int kWarpSize = (kDimCeil < PADDLE_CROSS_ENTROPY_WARP_SIZE)
+  constexpr int kWarpSize = (kDimCeil < PADDLE_WARP_SIZE)
                                 ? kDimCeil
-                                : PADDLE_CROSS_ENTROPY_WARP_SIZE;
+                                : PADDLE_WARP_SIZE;
   constexpr int kVSize = sizeof(VecT) / sizeof(T);
   constexpr int kIterations = kDimCeil / kWarpSize;
   constexpr int kIterationsV =
@@ -1622,9 +1622,9 @@ void SwitchWarpSoftmaxForward(T* loss,
   // use 128 threads per block to maximimize gpu utilization
   const int log2_elements = static_cast<int>(Log2Ceil(element_count));
   const int kDimCeil = 1 << log2_elements;
-  int kWarpSize = (kDimCeil < PADDLE_CROSS_ENTROPY_WARP_SIZE)
+  int kWarpSize = (kDimCeil < PADDLE_WARP_SIZE)
                       ? kDimCeil
-                      : PADDLE_CROSS_ENTROPY_WARP_SIZE;
+                      : PADDLE_WARP_SIZE;
   int batches_per_warp = (kDimCeil <= 128) ? 2 : 1;
   constexpr int threads_per_block = 128;
   int warps_per_block = (threads_per_block / kWarpSize);

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -35,12 +35,6 @@ namespace phi {
 
 #define ALIGN_BYTES 16
 
-#ifndef PADDLE_WARP_SIZE
-#define PADDLE_WARP_SIZE 32
-#endif
-#define PADDLE_WARP_MASK (PADDLE_WARP_SIZE - 1)
-#define PADDLE_WARP_SHIFT (PADDLE_WARP_SIZE == 64 ? 6 : 5)
-
 enum class SoftmaxMode { kSoftmax, kLogSoftmax, kCrossEntropy };
 
 // Wrapper of log function. Use log(float32) for float16

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -26,6 +26,12 @@ limitations under the License. */
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/kernels/elementwise_multiply_kernel.h"
 
+#ifndef PADDLE_WARP_SIZE
+#define PADDLE_WARP_SIZE 32
+#endif
+#define PADDLE_WARP_MASK (PADDLE_WARP_SIZE - 1)
+#define PADDLE_WARP_SHIFT (PADDLE_WARP_SIZE == 64 ? 6 : 5)
+
 #define SOFTMAX_ALIGN_BYTES 16
 #define MATRIX_SOFTMAX_ALIGN_BYTES 16
 #define MATRIX_SOFTMAX_THRESHOLD 100000
@@ -100,7 +106,7 @@ inline int CalcBlockSize(int vec_size, uint64_t dim_size) {
   }
 
   while (block_size < (max_block_size)) block_size *= 2;
-  block_size = std::max(block_size, static_cast<uint64_t>(32));
+  block_size = std::max(block_size, static_cast<uint64_t>(PADDLE_WARP_SIZE));
   return block_size;
 }
 
@@ -159,56 +165,56 @@ __device__ __forceinline__ void WarpReduceMaxDown(T* sum) {
 
 template <typename T>
 __inline__ __device__ void BlockReduceMax(T* val) {
-  static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
+  static __shared__ T shared[PADDLE_WARP_SIZE];
+  int lane = threadIdx.x & PADDLE_WARP_MASK;
+  int wid = threadIdx.x >> PADDLE_WARP_SHIFT;
 
-  WarpReduceMax<T, 1, 32>(val);
+  WarpReduceMax<T, 1, PADDLE_WARP_SIZE>(val);
 
   if (lane == 0) shared[wid] = *val;
 
   __syncthreads();
 
-  int block_span = (blockDim.x + warpSize - 1) >> 5;
+  int block_span = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   *val = (lane < block_span) ? shared[lane] : -1e10f;
-  WarpReduceMax<T, 1, 32>(val);
+  WarpReduceMax<T, 1, PADDLE_WARP_SIZE>(val);
 }
 
 template <typename T>
 __inline__ __device__ void BlockReduceSum(T* val) {
-  static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
+  static __shared__ T shared[PADDLE_WARP_SIZE];
+  int lane = threadIdx.x & PADDLE_WARP_MASK;
+  int wid = threadIdx.x >> PADDLE_WARP_SHIFT;
 
-  WarpReduceSum<T, 1, 32>(val);
+  WarpReduceSum<T, 1, PADDLE_WARP_SIZE>(val);
 
   __syncthreads();
   if (lane == 0) shared[wid] = *val;
 
   __syncthreads();
 
-  int block_span = (blockDim.x + warpSize - 1) >> 5;
+  int block_span = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   *val = (lane < block_span) ? shared[lane] : static_cast<T>(0.0f);
-  WarpReduceSum<T, 1, 32>(val);
+  WarpReduceSum<T, 1, PADDLE_WARP_SIZE>(val);
 }
 
 // Block reduction using shuffle-down with broadcast to all threads.
 template <typename T>
 __inline__ __device__ void BlockReduceMaxDown(T* val) {
-  static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
+  static __shared__ T shared[PADDLE_WARP_SIZE];
+  int lane = threadIdx.x & PADDLE_WARP_MASK;
+  int wid = threadIdx.x >> PADDLE_WARP_SHIFT;
 
-  WarpReduceMaxDown<T, 1, 32>(val);
+  WarpReduceMaxDown<T, 1, PADDLE_WARP_SIZE>(val);
 
   if (lane == 0) shared[wid] = *val;
 
   __syncthreads();
 
-  int block_span = (blockDim.x + warpSize - 1) >> 5;
+  int block_span = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   *val = (lane < block_span) ? shared[lane] : -1e10f;
   if (wid == 0) {
-    WarpReduceMaxDown<T, 1, 32>(val);
+    WarpReduceMaxDown<T, 1, PADDLE_WARP_SIZE>(val);
   }
   // Broadcast final result from thread 0 to all threads
   if (threadIdx.x == 0) {
@@ -220,21 +226,21 @@ __inline__ __device__ void BlockReduceMaxDown(T* val) {
 
 template <typename T>
 __inline__ __device__ void BlockReduceSumDown(T* val) {
-  static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
+  static __shared__ T shared[PADDLE_WARP_SIZE];
+  int lane = threadIdx.x & PADDLE_WARP_MASK;
+  int wid = threadIdx.x >> PADDLE_WARP_SHIFT;
 
-  WarpReduceSumDown<T, 1, 32>(val);
+  WarpReduceSumDown<T, 1, PADDLE_WARP_SIZE>(val);
 
   __syncthreads();
   if (lane == 0) shared[wid] = *val;
 
   __syncthreads();
 
-  int block_span = (blockDim.x + warpSize - 1) >> 5;
+  int block_span = (blockDim.x + warpSize - 1) >> PADDLE_WARP_SHIFT;
   *val = (lane < block_span) ? shared[lane] : static_cast<T>(0.0f);
   if (wid == 0) {
-    WarpReduceSumDown<T, 1, 32>(val);
+    WarpReduceSumDown<T, 1, PADDLE_WARP_SIZE>(val);
   }
   // Broadcast final result from thread 0 to all threads
   if (threadIdx.x == 0) {
@@ -619,11 +625,11 @@ __global__ void WarpSoftmaxForward(T* softmax,
                                    const IndexType stride,
                                    const IndexType element_count) {
   constexpr IndexType kDimCeil = 1 << Log2Elements;
-  constexpr IndexType kWarpSize = (kDimCeil < 32) ? kDimCeil : 32;
+  constexpr IndexType kWarpSize = (kDimCeil < PADDLE_WARP_SIZE) ? kDimCeil : PADDLE_WARP_SIZE;
   constexpr IndexType kVSize = sizeof(VecT) / sizeof(T);
   constexpr IndexType kLoops = kDimCeil / kWarpSize;
   constexpr IndexType kLoopsV = (kLoops >= kVSize) ? (kLoops / kVSize) : 1;
-  constexpr IndexType kBatchSize = (kDimCeil <= 32) ? 2 : 1;
+  constexpr IndexType kBatchSize = (kDimCeil <= PADDLE_WARP_SIZE) ? 2 : 1;
   IndexType first_batch =
       (static_cast<IndexType>(blockDim.y) * blockIdx.x + threadIdx.y) *
       kBatchSize;
@@ -740,9 +746,9 @@ __global__ void WarpSoftmaxBackward(T* dst,
                                     IndexType element_count) {
   constexpr IndexType kVSize = sizeof(VecT) / sizeof(T);
   constexpr IndexType kDimCeil = 1 << Log2Elements;
-  constexpr IndexType kWarpSize = (kDimCeil < 32) ? kDimCeil : 32;
+  constexpr IndexType kWarpSize = (kDimCeil < PADDLE_WARP_SIZE) ? kDimCeil : PADDLE_WARP_SIZE;
   constexpr IndexType kLoops = kDimCeil / kWarpSize;
-  constexpr IndexType kBatchSize = (kDimCeil <= 128) ? 2 : 1;
+  constexpr IndexType kBatchSize = (kDimCeil <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
   constexpr IndexType kLoopsV = (kLoops >= kVSize) ? (kLoops / kVSize) : 1;
   IndexType element_count_v = element_count / kVSize;
   IndexType first_batch =
@@ -961,7 +967,7 @@ static void GetBlockDim(int64_t mid_dim, int64_t low_dim, dim3* block) {
   constexpr int max_num_threads = 1024;
   int64_t block_x = int64_t(1) << Log2Ceil(low_dim);
   int64_t block_y = int64_t(1) << Log2Ceil(mid_dim);
-  block->x = std::min<int64_t>(block_x, 32);
+  block->x = std::min<int64_t>(block_x, PADDLE_WARP_SIZE);
   block->y = std::min<int64_t>(block_y, max_num_threads / block->x);
   block->x = std::min<int64_t>(block_x, max_num_threads / block->y);
 }
@@ -1477,7 +1483,7 @@ inline dim3 SoftMaxForwardGetBlockSize(uint64_t dim_size) {
   uint64_t block_size = 1;
   uint64_t max_block_size = std::min(dim_size, static_cast<uint64_t>(1024));
 
-  int warp_size = 32;
+  int warp_size = PADDLE_WARP_SIZE;
   if (max_block_size % warp_size == 0) {
     block_size = max_block_size;
   } else {
@@ -1543,13 +1549,13 @@ __device__ __forceinline__ AccT blockReduce(AccT* shared_mem,
 
   // Warp 0 is responsible for reducing the partial results produced by the
   // other warps.
-  uint32_t mask = (((uint64_t)1) << (blockDim.x / 32)) - 1;
-  if (threadIdx.x < 32) {
-    int lane = threadIdx.x % 32;
-    if (lane < blockDim.x / 32) {
+  uint32_t mask = (((uint64_t)1) << (blockDim.x / PADDLE_WARP_SIZE)) - 1;
+  if (threadIdx.x < PADDLE_WARP_SIZE) {
+    int lane = threadIdx.x % PADDLE_WARP_SIZE;
+    if (lane < blockDim.x / PADDLE_WARP_SIZE) {
 #pragma unroll
-      for (int i = 0; i < 32; ++i) {
-        warpVal = r(warpVal, shared_mem[lane * 32 + i]);
+      for (int i = 0; i < PADDLE_WARP_SIZE; ++i) {
+        warpVal = r(warpVal, shared_mem[lane * PADDLE_WARP_SIZE + i]);
       }
 #if !defined(USE_ROCM)
       __syncwarp(mask);
@@ -1565,7 +1571,7 @@ __device__ __forceinline__ AccT blockReduce(AccT* shared_mem,
   AccT blockVal = defaultVal;
 
   if (threadIdx.x == 0) {
-    for (int i = 0; i < blockDim.x / 32; ++i) {
+    for (int i = 0; i < blockDim.x / PADDLE_WARP_SIZE; ++i) {
       blockVal = r(blockVal, shared_mem[i]);
     }
     shared_mem[0] = blockVal;
@@ -2221,9 +2227,9 @@ __global__ void softmax_warp_forward(T* dst,
   // batches_per_warp and warp_size of the warp_softmax_forward_kernel method.
   constexpr IndexType next_power_of_two = 1 << log2_elements;
   constexpr IndexType warp_size_t =
-      (next_power_of_two < 32) ? next_power_of_two : 32;
+      (next_power_of_two < PADDLE_WARP_SIZE) ? next_power_of_two : PADDLE_WARP_SIZE;
   constexpr IndexType kWarpIterationSize = next_power_of_two / warp_size_t;
-  constexpr IndexType kWarpBatchSize = (next_power_of_two <= 128) ? 2 : 1;
+  constexpr IndexType kWarpBatchSize = (next_power_of_two <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
 
   IndexType first_batch =
       (static_cast<IndexType>(blockDim.y) * static_cast<IndexType>(blockIdx.x) +
@@ -2333,9 +2339,9 @@ __global__ void softmax_warp_backward(T* gradInput,
   // batches_per_warp and warp_size of the warp_softmax_backward_kernel method.
   constexpr IndexType next_power_of_two = 1 << log2_elements;
   constexpr IndexType warp_size_t =
-      (next_power_of_two < 32) ? next_power_of_two : 32;
+      (next_power_of_two < PADDLE_WARP_SIZE) ? next_power_of_two : PADDLE_WARP_SIZE;
   constexpr IndexType kWarpIterationSize = next_power_of_two / warp_size_t;
-  constexpr IndexType kWarpBatchSize = (next_power_of_two <= 128) ? 2 : 1;
+  constexpr IndexType kWarpBatchSize = (next_power_of_two <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
 
   IndexType first_batch =
       (static_cast<IndexType>(blockDim.y) * static_cast<IndexType>(blockIdx.x) +
@@ -2422,14 +2428,14 @@ void dispatch_softmax_forward(const GPUContext& dev_ctx,
 
   // This value must match the warp_size_t constexpr value computed inside
   // softmax_warp_forward.
-  IndexType warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  IndexType warp_size = (next_power_of_two < PADDLE_WARP_SIZE) ? next_power_of_two : PADDLE_WARP_SIZE;
 
   // This value must match the kWarpBatchSize constexpr value computed inside
   // softmax_warp_forward.
-  IndexType batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
+  IndexType batches_per_warp = (next_power_of_two <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
 
   // Use 128 threads per block to maximize GPU utilization.
-  constexpr IndexType threads_per_block = 128;
+  constexpr IndexType threads_per_block = PADDLE_WARP_SIZE * 4;
 
   IndexType warps_per_block = (threads_per_block / warp_size);
   IndexType batches_per_block = warps_per_block * batches_per_warp;
@@ -2476,9 +2482,9 @@ void dispatch_softmax_backward(const GPUContext& dev_ctx,
   IndexType log2_elements = Log2Ceil(softmax_elements);
   const IndexType next_power_of_two = 1 << log2_elements;
 
-  IndexType warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
-  IndexType batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
-  constexpr IndexType threads_per_block = 128;
+  IndexType warp_size = (next_power_of_two < PADDLE_WARP_SIZE) ? next_power_of_two : PADDLE_WARP_SIZE;
+  IndexType batches_per_warp = (next_power_of_two <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
+  constexpr IndexType threads_per_block = PADDLE_WARP_SIZE * 4;
 
   IndexType warps_per_block = (threads_per_block / warp_size);
   IndexType batches_per_block = warps_per_block * batches_per_warp;
@@ -2525,7 +2531,7 @@ void dispatch_host_softmax_forward(const GPUContext& dev_ctx,
                                    T* out_data) {
   constexpr IndexType VecSize = sizeof(float4) / sizeof(T);
   dim3 block = SoftMaxForwardGetBlockSize(dim_size);
-  size_t smem_reduction_size = block.x / 32 * sizeof(AccT);
+  size_t smem_reduction_size = block.x / PADDLE_WARP_SIZE * sizeof(AccT);
   auto max_elements_per_smem =
       (GetDeviceProp()->sharedMemPerBlock - smem_reduction_size) / sizeof(T);
 
@@ -2584,7 +2590,7 @@ void dispatch_host_softmax_backward(const GPUContext& dev_ctx,
   constexpr int VecSize = sizeof(float4) / sizeof(T);
   dim3 block = dim3(CalcBlockSize(VecSize, dim_size));
 
-  size_t smem_reduction_size = block.x / 32 * sizeof(AccT);
+  size_t smem_reduction_size = block.x / PADDLE_WARP_SIZE * sizeof(AccT);
   auto max_elements_per_smem =
       (GetDeviceProp()->sharedMemPerBlock - smem_reduction_size) / sizeof(T);
   bool can_use_smem = static_cast<size_t>(dim_size) < max_elements_per_smem;
@@ -2751,11 +2757,11 @@ void SoftmaxForwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
         D > std::numeric_limits<int32_t>::max()) {
       int dim_log2 = static_cast<int>(Log2Ceil(dim));
       IndexType dim_ceil = 1 << dim_log2;
-      int warp_size = (dim_ceil < 32) ? dim_ceil : 32;
-      int batches_per_warp = (dim_ceil <= 32) ? 2 : 1;
+      int warp_size = (dim_ceil < PADDLE_WARP_SIZE) ? dim_ceil : PADDLE_WARP_SIZE;
+      int batches_per_warp = (dim_ceil <= PADDLE_WARP_SIZE) ? 2 : 1;
 
       // use 128 threads per block to maximize gpu utilization
-      constexpr int threads_per_block = 128;
+      constexpr int threads_per_block = 4 * PADDLE_WARP_SIZE;
 
       int warps_per_block = (threads_per_block / warp_size);
       int batches_per_block = warps_per_block * batches_per_warp;
@@ -2890,10 +2896,10 @@ void SoftmaxBackwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
         D > std::numeric_limits<int32_t>::max()) {
       int dim_log2 = Log2Ceil(dim);
       IndexType dim_ceil = 1 << dim_log2;
-      int warp_size = (dim_ceil < 32) ? dim_ceil : 32;
-      int batches_per_warp = (dim_ceil <= 128) ? 2 : 1;
+      int warp_size = (dim_ceil < PADDLE_WARP_SIZE) ? dim_ceil : PADDLE_WARP_SIZE;
+      int batches_per_warp = (dim_ceil <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
 
-      constexpr int threads_per_block = 128;
+      constexpr int threads_per_block = 4 * PADDLE_WARP_SIZE;
 
       int warps_per_block = (threads_per_block / warp_size);
       int batches_per_block = warps_per_block * batches_per_warp;

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -26,12 +26,6 @@ limitations under the License. */
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/kernels/elementwise_multiply_kernel.h"
 
-#ifndef PADDLE_WARP_SIZE
-#define PADDLE_WARP_SIZE 32
-#endif
-#define PADDLE_WARP_MASK (PADDLE_WARP_SIZE - 1)
-#define PADDLE_WARP_SHIFT (PADDLE_WARP_SIZE == 64 ? 6 : 5)
-
 #define SOFTMAX_ALIGN_BYTES 16
 #define MATRIX_SOFTMAX_ALIGN_BYTES 16
 #define MATRIX_SOFTMAX_THRESHOLD 100000


### PR DESCRIPTION
## Summary

- **Remove** `add_definitions(-DPADDLE_CROSS_ENTROPY_WARP_SIZE=...)` from `paddle/phi/CMakeLists.txt`; iluvatar only needs to add `-DPADDLE_WARP_SIZE=64` in their own CMake — no patch required.
- **Rename** `PADDLE_CROSS_ENTROPY_WARP_SIZE` → `PADDLE_WARP_SIZE` and `PADDLE_CE_WARP_MASK/SHIFT` → `PADDLE_WARP_MASK/SHIFT` throughout `cross_entropy_kernel.cu` (default guard kept as 32).
- **Replace** all warp-size hardcodes (`32`, `0x1f`, `>>5`, `128` threads, `shared[32]`, `kBatchSize` comparisons) with `PADDLE_WARP_SIZE` and its derived macros in `softmax_gpudnn.h`, covering both the non-CUDA and `PADDLE_WITH_CUDA` code paths.

## Behaviour

| Build | `PADDLE_WARP_SIZE` | Effect |
|---|---|---|
| NVIDIA | 32 (default) | Identical to before |
| iluvatar | 64 (via `-DPADDLE_WARP_SIZE=64`) | All warp-size logic auto-adapts |

## Test plan

- [ ] NVIDIA: build without `-DPADDLE_WARP_SIZE`, confirm default = 32, no regression
- [ ] iluvatar: build with `-DPADDLE_WARP_SIZE=64`, confirm no patch needed
- [ ] Search `PADDLE_CROSS_ENTROPY_WARP_SIZE` in repo — should return 0 results
- [ ] Search `& 0x1f`, `>> 5`, `shared[32]` in `softmax_gpudnn.h` outside `PADDLE_WITH_CUDA` — should return 0 results

🤖 Generated with [Ducc](https://github.com/anthropics/claude-code)